### PR TITLE
bugfix: slug in categoryByPage and categoryVar check in frontmatter

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -16,7 +16,8 @@ module.exports = function(eleventyConfig, options={
   itemCollection: "posts",
 }) {
     const categoryCollection = options.categoryCollection || options.categoryVar;
-    const perPageCount = options.perPageCount || 5
+    const categoryVar = options.categoryVar;
+    const perPageCount = options.perPageCount || 5;
 
     // Creates the collection
     eleventyConfig.addCollection(categoryCollection, function(collections) {
@@ -26,8 +27,8 @@ module.exports = function(eleventyConfig, options={
 
       const categoriesWithPosts = tagArray.map(category => {
         let filteredPosts = posts.filter(post => {
-          if (!post.data[categoryCollection]) return false
-          return post.data[categoryCollection].includes(category)}
+          if (!post.data[categoryVar]) return false
+          return post.data[categoryVar].includes(category)}
           ).flat();
           
         return { 
@@ -51,8 +52,8 @@ module.exports = function(eleventyConfig, options={
 
         for(let tagName of tagArray) {
           const filteredPosts = posts.filter(post => {
-            if (!post.data[categoryCollection]) return false
-            return post.data[categoryCollection].includes(tagName)}
+            if (!post.data[categoryVar]) return false
+            return post.data[categoryVar].includes(tagName)}
             ).flat();
 
           let tagItems = filteredPosts.reverse();
@@ -61,11 +62,11 @@ module.exports = function(eleventyConfig, options={
           for( let pageNumber = 0, max = pagedItems.length; pageNumber < max; pageNumber++) {
             const currentNumber = pageNumber + 1
             tagMap.push({
-              slug: tagName,
+              slug: slugify(tagName),
               title: tagName,
               totalPages,
               posts: pagedItems[pageNumber],
-              permalinkScheme: `${tagName}${currentNumber > 1 ? `/${currentNumber}` : ''}/index.html`,
+              permalinkScheme: `${slugify(tagName)}${currentNumber > 1 ? `/${currentNumber}` : ''}/index.html`,
               pages: {
                 current: currentNumber,
                 next: currentNumber != totalPages && currentNumber + 1,

--- a/demo/.eleventy.js
+++ b/demo/.eleventy.js
@@ -7,7 +7,8 @@ module.exports = function(eleventyConfig) {
         perPageCount: 4
     })
     eleventyConfig.addPlugin(categoryPlugin, {
-        categoryVar: "articleCategories",
+        categoryVar: "categories",
+        categoryCollection: "articleCategories",
         itemsCollection: "articles",
         perPageCount: 2
     })

--- a/demo/articles/blog-a.md
+++ b/demo/articles/blog-a.md
@@ -1,5 +1,6 @@
 ---
-title: Article 1
+title: Article A
+categories: ['dev', 'tutorials 101']
 ---
 
 Hello world

--- a/demo/articles/blog-b.md
+++ b/demo/articles/blog-b.md
@@ -1,6 +1,6 @@
 ---
 title: Article B
-articleCategories: ['dev']
+categories: ['dev']
 ---
 
 Hello world

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,7 +3,7 @@ layout: "base.html"
 ---
 
 
-<h1>Categories</h1>
+<h1>Post Categories</h1>
 {% for category in collections.categories %}
     <div>
         <h2><a href="/posts/{{category.slug}}/">{{ category.title }}</a></h2>
@@ -21,7 +21,7 @@ layout: "base.html"
 {% for post in collections.articles %}
     <li>{{post.data.title}}</li>
 {% endfor %}
-<h1>Categories</h1>
+<h1>Article Categories</h1>
 {% for category in collections.articleCategories %}
     <div>
         <h2><a href="/articles/{{category.slug}}/">{{ category.title }}</a></h2>


### PR DESCRIPTION
@brob as mentioned in the README, `categoryVar` is the variable in the frontmatter that is used to assign categories to your content. And `categoryCollection` is used if you want to name the collection different from the value that is set in `categoryVar`.

Thus, this pull request fixes two things:
- `categoryVar` is used to check in the frontmatter of posts
- for posts having categories with spaces e.g: `['dev', 'UI Designs']`, the slug wasn't properly genearted, added slugify.

`.eleventy.js` and `articles` in the **demo/** folder have been updated to demonstrate this new change.